### PR TITLE
Migrate project to Play 2.4.0 and play-pac4j 1.5.0-SNAPSHOT

### DIFF
--- a/app/modules/SecurityModule.java
+++ b/app/modules/SecurityModule.java
@@ -1,0 +1,15 @@
+package modules;
+
+import com.google.inject.AbstractModule;
+import security.SecurityConfig;
+import security.impl.SecurityConfigAll;
+
+/**
+ * Created by hv01016 on 10-6-2015.
+ */
+public class SecurityModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(SecurityConfig.class).to(SecurityConfigAll.class).asEagerSingleton();
+    }
+}

--- a/app/security/SecurityConfig.java
+++ b/app/security/SecurityConfig.java
@@ -1,0 +1,7 @@
+package security;
+
+/**
+ * Created by hv01016 on 10-6-2015.
+ */
+public interface SecurityConfig {
+}

--- a/app/security/impl/SecurityConfigAll.java
+++ b/app/security/impl/SecurityConfigAll.java
@@ -1,4 +1,4 @@
-package controllers;
+package security.impl;
 
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.core.client.Clients;
@@ -11,29 +11,28 @@ import org.pac4j.oauth.client.TwitterClient;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.play.Config;
 import org.pac4j.saml.client.Saml2Client;
+import play.Configuration;
+import security.SecurityConfig;
 
-import play.Application;
-import play.GlobalSettings;
-import play.Play;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
-//import play.mvc.Http.RequestHeader;
+/**
+ * Implemmentation of {@link security.SecurityConfig} adding all posible
+ * clients to the configuration.
+ **/
+@Singleton
+public class SecurityConfigAll implements SecurityConfig {
 
-public class Global extends GlobalSettings {
-
-    /*@Override
-    public Result onError(final RequestHeader requestHeader, final Throwable t) {
-        return play.mvc.Controller.internalServerError(views.html.error500.render());
-    }*/
-
-    @Override
-    public void onStart(final Application app) {
+    @Inject
+    public SecurityConfigAll(Configuration configuration) {
         Config.setErrorPage401(views.html.error401.render().toString());
         Config.setErrorPage403(views.html.error403.render().toString());
 
-        final String fbId = Play.application().configuration().getString("fbId");
-        final String fbSecret = Play.application().configuration().getString("fbSecret");
-        final String baseUrl = Play.application().configuration().getString("baseUrl");
-        final String casUrl = Play.application().configuration().getString("casUrl");
+        final String fbId = configuration.getString("fbId");
+        final String fbSecret = configuration.getString("fbSecret");
+        final String baseUrl = configuration.getString("baseUrl");
+        final String casUrl = configuration.getString("casUrl");
 
         // OAuth
         final FacebookClient facebookClient = new FacebookClient(fbId, fbSecret);

--- a/build.sbt
+++ b/build.sbt
@@ -4,17 +4,17 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.6"
 
 libraryDependencies ++= Seq(
-  "org.pac4j" % "play-pac4j_java" % "1.4.0",
+  "org.pac4j" % "play-pac4j_java" % "1.5.0-SNAPSHOT",
   "org.pac4j" % "pac4j-http" % "1.7.0",
   "org.pac4j" % "pac4j-cas" % "1.7.0",
   "org.pac4j" % "pac4j-openid" % "1.7.0",
   "org.pac4j" % "pac4j-oauth" % "1.7.0",
   "org.pac4j" % "pac4j-saml" % "1.7.0",
   "org.pac4j" % "pac4j-oidc" % "1.7.0",
-  "com.typesafe.play" % "play-cache_2.11" % "2.3.0"
+  "com.typesafe.play" % "play-cache_2.11" % "2.4.0"
 )
 
 resolvers ++= Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,20 +5,14 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="?FicVyTZjgA]Us>iXsVu[1<fSfRTicvJp]CSHxpW@PATvICdao_10V3VNaDCD394"
+play.crypto.secret="?FicVyTZjgA]Us>iXsVu[1<fSfRTicvJp]CSHxpW@PATvICdao_10V3VNaDCD394"
 
 # The application languages
 # ~~~~~
-application.langs="en"
-
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-global=controllers.Global
+play.i18n.langs="en"
 
 # Database configuration
-# ~~~~~ 
+# ~~~~~
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
@@ -42,18 +36,7 @@ global=controllers.Global
 #
 # ebean.default="models.*"
 
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-logger.org.pac4j.play=DEBUG
-logger.controllers=DEBUG
+play.modules.enabled += "modules.SecurityModule"
 
 # Identifiers and URLs
 fbId="132736803558924"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel - %logger - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <!--
+    The logger name is typically the Java/Scala package name.
+    This configures the log level to log at for a package and its children packages.
+  -->
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+  <logger name="org.pac4j.play" level="DEBUG" />
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-# play 2.3
-sbt.version=0.13.5
+# play 2.4
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
 
 // web plugins
 


### PR DESCRIPTION
The demo project appears to work now with Play 2.4. 

As play-pac4j still needs to support the new dependency injection style controllers, this project uses the old style controllers for the moment. 