### PR TITLE
update modules to 1.8.8; langs as List

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,19 +8,19 @@ scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
   "org.pac4j" % "play-pac4j" % "2.2.0-SNAPSHOT",
-  "org.pac4j" % "pac4j-http" % "1.8.6",
-  "org.pac4j" % "pac4j-cas" % "1.8.6",
-  "org.pac4j" % "pac4j-openid" % "1.8.6",
-  "org.pac4j" % "pac4j-oauth" % "1.8.6",
-  "org.pac4j" % "pac4j-saml" % "1.8.6",
-  "org.pac4j" % "pac4j-oidc" % "1.8.6",
-  "org.pac4j" % "pac4j-gae" % "1.8.6",
-  "org.pac4j" % "pac4j-jwt" % "1.8.6",
-  "org.pac4j" % "pac4j-ldap" % "1.8.6",
-  "org.pac4j" % "pac4j-sql" % "1.8.6",
-  "org.pac4j" % "pac4j-mongo" % "1.8.6",
-  "org.pac4j" % "pac4j-stormpath" % "1.8.6",
-  "com.typesafe.play" % "play-cache_2.11" % "2.4.0"
+  "org.pac4j" % "pac4j-http" % "1.8.8",
+  "org.pac4j" % "pac4j-cas" % "1.8.8",
+  "org.pac4j" % "pac4j-openid" % "1.8.8",
+  "org.pac4j" % "pac4j-oauth" % "1.8.8",
+  "org.pac4j" % "pac4j-saml" % "1.8.8",
+  "org.pac4j" % "pac4j-oidc" % "1.8.8",
+  "org.pac4j" % "pac4j-gae" % "1.8.8",
+  "org.pac4j" % "pac4j-jwt" % "1.8.8",
+  "org.pac4j" % "pac4j-ldap" % "1.8.8",
+  "org.pac4j" % "pac4j-sql" % "1.8.8",
+  "org.pac4j" % "pac4j-mongo" % "1.8.8",
+  "org.pac4j" % "pac4j-stormpath" % "1.8.8",
+  "com.typesafe.play" % "play-cache_2.11" % "2.5.3"
 )
 
 //resolvers := Seq(Resolver.mavenLocal)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -9,7 +9,7 @@ play.crypto.secret="?FicVyTZjgA]Us>iXsVu[1<fSfRTicvJp]CSHxpW@PATvICdao_10V3VNaDC
 
 # The application languages
 # ~~~~~
-play.i18n.langs="en"
+play.i18n.langs= ["en"]
 
 # Database configuration
 # ~~~~~


### PR DESCRIPTION
**pac4j** libraries updated to **1.8.8**

The `play.i18n.langs` must be a  list in **Play 2.5**. There is no error if you run in development mode, but I got it when tried to deploy demo: `play.i18n.langs has type STRING rather than LIST`.